### PR TITLE
Introduce a new config `holiday_hours`

### DIFF
--- a/lib/working_hours/computation.rb
+++ b/lib/working_hours/computation.rb
@@ -76,7 +76,7 @@ module WorkingHours
         end
         # find first working range after time
         time_in_day = time.seconds_since_midnight
-        (config[:working_hours][time.wday] || {}).each do |from, to|
+        (config[:holiday_hours][time.to_date.to_s] || config[:working_hours][time.wday] || {}).each do |from, to|
           return time if time_in_day >= from and time_in_day < to
           return time + (from - time_in_day) if from >= time_in_day
         end
@@ -222,6 +222,5 @@ module WorkingHours
       else time
       end
     end
-
   end
 end

--- a/spec/working_hours/computation_spec.rb
+++ b/spec/working_hours/computation_spec.rb
@@ -146,10 +146,15 @@ describe WorkingHours::Computation do
       WorkingHours::Config.time_zone = 'Tokyo'
       expect(advance_to_working_time(Time.new(2014, 4, 7, 0, 0, 0)).zone).to eq('JST')
     end
+
+    it 'jumps outside holiday hours', :focus do
+      WorkingHours::Config.working_hours = { fri: { '08:00' => '18:00' } }
+      WorkingHours::Config.holiday_hours = { '2019-12-27' => { '10:00' => '18:00' } }
+      expect(advance_to_working_time(Time.utc(2019, 12, 27, 9))).to eq(Time.utc(2019, 12, 27, 10))
+    end
   end
 
   describe '#advance_to_closing_time' do
-
     it 'jumps non-working day' do
       WorkingHours::Config.holidays = [Date.new(2014, 5, 1)]
       holiday = Time.utc(2014, 5, 1, 12, 0)

--- a/spec/working_hours/config_spec.rb
+++ b/spec/working_hours/config_spec.rb
@@ -3,7 +3,6 @@ require 'spec_helper'
 describe WorkingHours::Config do
 
   describe '.working_hours' do
-
     let(:config) { WorkingHours::Config.working_hours }
     let(:config2) { { :mon => { '08:00' => '14:00' } } }
     let(:config3) { { :tue => { '10:00' => '16:00' } } }
@@ -155,7 +154,132 @@ describe WorkingHours::Config do
           1.working.hour.ago
         }.to raise_error(WorkingHours::InvalidConfiguration, 'Invalid type for `mon`: String - must be Hash')
       end
+    end
+  end
 
+  describe '.holiday_hours' do
+    let(:config) { WorkingHours::Config.holiday_hours }
+    let(:config2) { { '2019-12-01' => { '08:00' => '14:00' } } }
+    let(:config3) { { '2019-12-02' => { '10:00' => '16:00' } } }
+
+    it 'has a default config' do
+      expect(config).to be_kind_of(Hash)
+    end
+
+    it 'is thread safe' do
+      expect(WorkingHours::Config.holiday_hours).to eq(config)
+
+      thread = Thread.new do
+        WorkingHours::Config.holiday_hours = config2
+        expect(WorkingHours::Config.holiday_hours).to eq(config2)
+        Thread.stop
+        expect(WorkingHours::Config.holiday_hours).to eq(config2)
+      end
+
+      expect {
+        sleep 0.1 # let the thread begin its execution
+      }.not_to change { WorkingHours::Config.holiday_hours }.from(config)
+
+      expect {
+        WorkingHours::Config.holiday_hours = config3
+      }.to change { WorkingHours::Config.holiday_hours }.from(config).to(config3)
+
+      expect {
+        thread.run
+        thread.join
+      }.not_to change { WorkingHours::Config.holiday_hours }.from(config3)
+    end
+
+    it 'is fiber safe' do
+      expect(WorkingHours::Config.holiday_hours).to eq(config)
+
+      fiber = Fiber.new do
+        WorkingHours::Config.holiday_hours = config2
+        expect(WorkingHours::Config.holiday_hours).to eq(config2)
+        Fiber.yield
+        expect(WorkingHours::Config.holiday_hours).to eq(config2)
+      end
+
+      expect {
+        fiber.resume
+      }.not_to change { WorkingHours::Config.holiday_hours }.from(config)
+
+      expect {
+        WorkingHours::Config.holiday_hours = config3
+      }.to change { WorkingHours::Config.holiday_hours }.from(config).to(config3)
+
+      expect {
+        fiber.resume
+      }.not_to change { WorkingHours::Config.holiday_hours }.from(config3)
+    end
+
+    it 'is initialized from last known global config' do
+      WorkingHours::Config.holiday_hours = {'2019-12-01' => {'08:00' => '14:00'}}
+      Thread.new {
+        expect(WorkingHours::Config.holiday_hours).to match '2019-12-01' => {'08:00' => '14:00'}
+      }.join
+    end
+
+    it 'should support multiple timespan per day' do
+      time_sheet = {'2019-12-01' => {'08:00' => '12:00', '14:00' => '18:00'}}
+      WorkingHours::Config.holiday_hours = time_sheet
+      expect(config).to eq(time_sheet)
+    end
+
+    describe 'validations' do
+      it 'rejects invalid day' do
+        expect {
+          WorkingHours::Config.holiday_hours = {'2019-12-01' => 1, 'aaaaaa' => 2}
+        }.to raise_error(WorkingHours::InvalidConfiguration, "Invalid day identifier(s): Must be in the format 'YYYY-MM-DD'")
+      end
+
+      it 'rejects other type than hash' do
+        expect {
+          WorkingHours::Config.holiday_hours = {'2019-12-01' => []}
+        }.to raise_error(WorkingHours::InvalidConfiguration, "Invalid type for `2019-12-01`: Array - must be Hash")
+      end
+
+      it 'rejects empty range' do
+        expect {
+          WorkingHours::Config.holiday_hours = {'2019-12-01' => {}}
+        }.to raise_error(WorkingHours::InvalidConfiguration, "No working hours given for day `2019-12-01`")
+      end
+
+      it 'rejects invalid time format' do
+        expect {
+          WorkingHours::Config.holiday_hours = {'2019-12-01' => {'8:0' => '12:00'}}
+        }.to raise_error(WorkingHours::InvalidConfiguration, "Invalid time: 8:0 - must be 'HH:MM(:SS)'")
+
+        expect {
+          WorkingHours::Config.holiday_hours = {'2019-12-01' => {'08:00' => '24:10'}}
+        }.to raise_error(WorkingHours::InvalidConfiguration, "Invalid time: 24:10 - outside of day")
+      end
+
+      it 'rejects invalid range' do
+        expect {
+          WorkingHours::Config.holiday_hours = {'2019-12-01' => {'12:30' => '12:00'}}
+        }.to raise_error(WorkingHours::InvalidConfiguration, "Invalid range: 12:30 => 12:00 - ends before it starts")
+      end
+
+      it 'rejects overlapping range' do
+        expect {
+          WorkingHours::Config.holiday_hours = {'2019-12-01' => {'08:00' => '13:00', '12:00' => '18:00'}}
+        }.to raise_error(WorkingHours::InvalidConfiguration, "Invalid range: 12:00 => 18:00 - overlaps previous range")
+      end
+
+      it 'does not reject out-of-order, non-overlapping ranges' do
+        expect {
+          WorkingHours::Config.holiday_hours = {'2019-12-01' => {'10:00' => '11:00', '08:00' => '09:00'}}
+        }.not_to raise_error
+      end
+
+      it 'raises an error when precompiling if working hours are invalid after assignment' do
+        WorkingHours::Config.holiday_hours = {'2019-12-01' => {'10:00' => '11:00', '08:00' => '09:00'}}
+        WorkingHours::Config.holiday_hours['2019-12-01'] = 'Not correct'
+        expect {
+          1.working.hour.ago
+        }.to raise_error(WorkingHours::InvalidConfiguration, 'Invalid type for `2019-12-01`: String - must be Hash')
+      end
     end
   end
 

--- a/spec/working_hours/config_spec.rb
+++ b/spec/working_hours/config_spec.rb
@@ -267,6 +267,7 @@ describe WorkingHours::Config do
     it 'computes an optimized version' do
       expect(subject).to eq({
           :working_hours => [nil, {32400=>61200}, {32400=>61200}, {32400=>61200}, {32400=>61200}, {32400=>61200}],
+          :holiday_hours => {},
           :holidays => Set.new([]),
           :time_zone => ActiveSupport::TimeZone['UTC']
         })
@@ -276,6 +277,7 @@ describe WorkingHours::Config do
       WorkingHours::Config.working_hours = {:mon => {'20:32:59' => '22:59:59'}}
       expect(subject).to eq({
         :working_hours => [nil, {73979 => 82799}],
+        :holiday_hours => {},
         :holidays => Set.new([]),
         :time_zone => ActiveSupport::TimeZone['UTC']
       })
@@ -285,6 +287,7 @@ describe WorkingHours::Config do
       WorkingHours::Config.working_hours = {:mon => {'20:00' => '24:00'}}
       expect(subject).to eq({
         :working_hours => [nil, {72000 => 86399.999999}],
+        :holiday_hours => {},
         :holidays => Set.new([]),
         :time_zone => ActiveSupport::TimeZone['UTC']
       })


### PR DESCRIPTION
Setting holiday_hours lets you override the working hours for a specific day (e.g. if a company is working different hours during a holiday period vs their day-to-day hours).